### PR TITLE
Support for subclasses of FormContainerBlock. This closes #41

### DIFF
--- a/src/BVNetwork.Attend.Forms/Controllers/AttendFormContainerBlockController.cs
+++ b/src/BVNetwork.Attend.Forms/Controllers/AttendFormContainerBlockController.cs
@@ -20,7 +20,7 @@ using EPiServer.Forms.Implementation.Elements.BaseClasses;
 namespace BVNetwork.Attend.Forms.Controllers
 {
 
-    [TemplateDescriptor(AvailableWithoutTag = true, Default = true, ModelType = typeof(FormContainerBlock), TagString = "AttendContentArea", TemplateTypeCategory = TemplateTypeCategories.MvcPartialController)]
+    [TemplateDescriptor(AvailableWithoutTag = true, Default = true, ModelType = typeof(FormContainerBlock), TagString = "AttendContentArea", TemplateTypeCategory = TemplateTypeCategories.MvcPartialController, Inherited = true)]
     public class AttendFormContainerBlockController : FormContainerBlockController
     {
         public override ActionResult Index(FormContainerBlock currentBlock)


### PR DESCRIPTION
Lets custom subclasses of FormContainerBlock use the supplied AttendFormContainerBlockController in Attend.
This will make Episerver Attend work out of the box for customers using a custom episerver form implementation.
